### PR TITLE
Update web3 dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,14 +4,14 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[cljs-web3 "0.19.0-0-9"]
+  :dependencies [[io.github.district0x/cljs-web3-next "0.2.0-SNAPSHOT"]
                  [day8.re-frame/async-flow-fx "0.0.8"]
                  [district0x.re-frame/web3-fx "1.0.4"]
-                 [district0x/district-ui-web3 "1.0.1"]
+                 [io.github.district0x/district-ui-web3 "1.3.3-SNAPSHOT"]
                  [district0x/re-frame-spec-interceptors "1.0.1"]
                  [mount "0.1.11"]
-                 [org.clojure/clojurescript "1.9.946"]
-                 [re-frame "0.10.2"]]
+                 [org.clojure/clojurescript "1.10.3"]
+                 [re-frame "1.2.0"]]
 
   :doo {:paths {:karma "./node_modules/karma/bin/karma"}}
 
@@ -20,7 +20,7 @@
                           [karma-cli "1.0.1"]
                           [karma-cljs-test "0.1.0"]]}
 
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.8.0"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.11.1"]
                                   [com.cemerick/piggieback "0.2.2"]
                                   [org.clojure/tools.nrepl "0.2.13"]
                                   [day8.re-frame/test "0.1.5"]]

--- a/src/district/ui/web3_balances.cljs
+++ b/src/district/ui/web3_balances.cljs
@@ -1,6 +1,6 @@
 (ns district.ui.web3-balances
   (:require
-    [cljs-web3.core :as web3]
+    [cljs-web3-next.core :as web3]
     [cljs.spec.alpha :as s]
     [district.ui.web3-balances.events :as events]
     [district.ui.web3]

--- a/src/district/ui/web3_balances/events.cljs
+++ b/src/district/ui/web3_balances/events.cljs
@@ -1,7 +1,7 @@
 (ns district.ui.web3-balances.events
   (:require
-    [cljs-web3.core :as web3]
-    [cljs-web3.eth :as web3-eth]
+    [cljs-web3-next.core :as web3]
+    [cljs-web3-next.eth :as web3-eth]
     [cljs.spec.alpha :as s]
     [day8.re-frame.async-flow-fx]
     [district.ui.web3-balances.queries :as queries]

--- a/src/district/ui/web3_balances/queries.cljs
+++ b/src/district/ui/web3_balances/queries.cljs
@@ -1,5 +1,5 @@
 (ns district.ui.web3-balances.queries
-  (:require [cljs-web3.core :as web3]))
+  (:require [cljs-web3-next.core :as web3]))
 
 (defn contracts [db]
   (-> db :district.ui.web3-balances :contracts))


### PR DESCRIPTION
Because some core libraries (cljs-web3-next) moved to Web3.js 1.7,
this one needs its dependencies bumped as well